### PR TITLE
Add guide build to makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,3 +57,6 @@ test:
 
 test_report:
 	docker run --rm --workdir=/var/www/html/plugins/reports/pprReviewsReportPlugin -v $(PWD)/pprReviewsReportPlugin:/var/www/html/plugins/reports/pprReviewsReportPlugin $(PPR_OJS_TEST_IMAGE) tests/run_tests.sh
+
+guides:
+	docker run -it --rm -v $(PWD):/docs sphinxdoc/sphinx:7.3.6 bash -c "cd docs/sphinx-guides && pip3 install -r requirements.txt && make clean && make html"

--- a/README.md
+++ b/README.md
@@ -54,6 +54,9 @@ Build the OJS Docker image with XDebug support for OJS version 3.3:
 Build the OJS Docker image with XDebug support for OJS version 3.4:
 ``make docker34``
 
+Build the PPR-OJS documentation also available at [https://ppr-ojs.readthedocs.io/](https://ppr-ojs.readthedocs.io/)
+``make guides``
+
 ### Start the OJS application
 The first time we start the OJS application, the ojs-entry-point script will copy the source code into the ``environment/data/ojs/src`` folder.
 This will take around 5 minutes to complete. After the copy is made, the script will start the Apache server. In subsequent runs, the copy is bypassed on startup.


### PR DESCRIPTION
**What this PR does / why we need it**:
Adding to the makefile the docker command to build the guides

**Which issue(s) this PR closes**:

Closes #61 
