### PR TITLE
Added scheduled task to send a notification after a submission is closed

### DIFF
--- a/pprOjsPlugin/locale/en_US/locale.po
+++ b/pprOjsPlugin/locale/en_US/locale.po
@@ -177,7 +177,7 @@ msgid "plugins.generic.pprPlugin.settings.reviewSentAuthorEnabledDate.label"
 msgstr "Date from which submitted review files will be used to send review sent notifications to authors"
 
 msgid "plugins.generic.pprPlugin.settings.submissionClosedAuthorTaskEnabled.label"
-msgstr "Add automated notification to the author after a submission is closed"
+msgstr "Add automated notification to authors after a submission is closed"
 
 msgid "plugins.generic.pprPlugin.settings.submissionClosedAuthorWaitingDays.label"
 msgstr "Number of days to wait after a submission is closed to send a notification to the author"

--- a/pprOjsPlugin/locale/en_US/locale.po
+++ b/pprOjsPlugin/locale/en_US/locale.po
@@ -176,6 +176,12 @@ msgstr "Number of days to wait after a review is sent to send notifications to t
 msgid "plugins.generic.pprPlugin.settings.reviewSentAuthorEnabledDate.label"
 msgstr "Date from which submitted review files will be used to send review sent notifications to authors"
 
+msgid "plugins.generic.pprPlugin.settings.submissionClosedAuthorTaskEnabled.label"
+msgstr "Add automated notification to the author after a submission is closed"
+
+msgid "plugins.generic.pprPlugin.settings.submissionClosedAuthorWaitingDays.label"
+msgstr "Number of days to wait after a submission is closed to send a notification to the author"
+
 msgid "plugins.generic.pprPlugin.settings.emailContributorsEnabled.label"
 msgstr "Add checkbox to allow authors to choose if contributors should be notified"
 

--- a/pprOjsPlugin/scheduledTasks.xml
+++ b/pprOjsPlugin/scheduledTasks.xml
@@ -26,7 +26,7 @@
 	</task>
 
 	<task class="plugins.generic.pprOjsPlugin.tasks.PPRSubmissionClosedAuthorNotification">
-		<descr>Custom notification for authors a period of time a submission is closed</descr>
+		<descr>Custom notification for authors a period of time after a submission is closed</descr>
 		<frequency dayofweek="6"/>
 	</task>
 </scheduled_tasks>

--- a/pprOjsPlugin/scheduledTasks.xml
+++ b/pprOjsPlugin/scheduledTasks.xml
@@ -24,4 +24,9 @@
 		<descr>Custom notification for authors when a review is sent</descr>
 		<frequency hour="0"/>
 	</task>
+
+	<task class="plugins.generic.pprOjsPlugin.tasks.PPRSubmissionClosedAuthorNotification">
+		<descr>Custom notification for authors a period of time a submission is closed</descr>
+		<frequency dayofweek="6"/>
+	</task>
 </scheduled_tasks>

--- a/pprOjsPlugin/services/email/PPRFirstNameEmailService.inc.php
+++ b/pprOjsPlugin/services/email/PPRFirstNameEmailService.inc.php
@@ -19,6 +19,7 @@ class PPRFirstNameEmailService {
             'PPR_REVIEW_SUBMITTED',
             'PPR_SUBMISSION_APPROVED',
             'PPR_REVIEW_SENT_AUTHOR',
+            'PPR_SUBMISSION_CLOSED_AUTHOR',
             //BATCH 3
             'REVIEW_REQUEST' ,
             'REVIEW_REQUEST_SUBSEQUENT',

--- a/pprOjsPlugin/settings/PPRPluginSettings.inc.php
+++ b/pprOjsPlugin/settings/PPRPluginSettings.inc.php
@@ -46,6 +46,9 @@ class PPRPluginSettings {
         'reviewUploadFileValidationEnabled' => ['bool', null],
         'reviewAttachmentsOverrideEnabled' => ['bool', null],
 
+        'submissionClosedAuthorTaskEnabled' => ['bool', null],
+        'submissionClosedAuthorWaitingDays' => ['int', 365],
+
         'authorSubmissionSurveyHtml' => ['string', null],
         'authorDashboardSurveyHtml' => ['string', null],
         'reviewerSurveyHtml' => ['string', null],
@@ -230,6 +233,14 @@ class PPRPluginSettings {
 
     public function reviewAttachmentsOverrideEnabled() {
         return $this->getValue('reviewAttachmentsOverrideEnabled');
+    }
+
+    public function submissionClosedAuthorTaskEnabled() {
+        return $this->getValue('submissionClosedAuthorTaskEnabled');
+    }
+
+    public function submissionClosedAuthorWaitingDays() {
+        return $this->getValue('submissionClosedAuthorWaitingDays');
     }
 
     public function fileUploadTextOverrideEnabled() {

--- a/pprOjsPlugin/tasks/PPRReviewSentAuthorNotification.inc.php
+++ b/pprOjsPlugin/tasks/PPRReviewSentAuthorNotification.inc.php
@@ -5,7 +5,10 @@ use function PHP81_BC\strftime;
 require_once(dirname(__FILE__) . '/PPRScheduledTask.inc.php');
 
 /**
- * Notification to authors to review the program a period after a review has been sent to them
+ * Notification, in the form of an email, to authors. The email will be sent a period of time after
+ * a review has been sent to them. This is used to send a survey to the author.
+ * The initial requirement was to send an email after a week,
+ * but the time in days is configurable in the plugin settings.
  */
 class PPRReviewSentAuthorNotification extends PPRScheduledTask {
 
@@ -92,6 +95,8 @@ class PPRReviewSentAuthorNotification extends PPRScheduledTask {
             $metrics['sentReviewFiles']++;
 
             //REVIEW FILE HAS BEEN SENT => SET NOTIFICATION FLAG
+            //THIS FLAG IS NEEDED AS THE START POINT TO COUNT THE NUMBER OF DAYS UNTIL WE CAN SEND THE EMAIL
+            //WE USE THE DateRead FIELD TO MARK THAT THE EMAIL WAS SENT
             $reviewerId = $reviewFile->getUploaderUserId();
             $reviewAssignmentId = $reviewFile->getData('assocId');
             $authorNotifications = $pprNotificationRegistry->getReviewSentAuthorNotifications($reviewerId, $reviewAssignmentId);

--- a/pprOjsPlugin/tasks/PPRSubmissionClosedAuthorNotification.inc.php
+++ b/pprOjsPlugin/tasks/PPRSubmissionClosedAuthorNotification.inc.php
@@ -100,6 +100,8 @@ class PPRSubmissionClosedAuthorNotification extends PPRScheduledTask {
                 $metrics['closedSubmissionsAfterPeriod']++;
 
                 if (!$this->requestedRevisionsForSubmission($closedSubmission)) {
+                    // ALL CLOSED SUBMISSIONS SHOULD HAVE BEEN SENT TO AUTHOR
+                    // LOG TO DEBUG WITH PRODUCT TEAM
                     $this->log($context, sprintf("sendToAuthor not found - closedSubmission=%s", $closedSubmission->getId()));
                     $metrics['sendToAuthorMissing']++;
                     continue;

--- a/pprOjsPlugin/tasks/PPRSubmissionClosedAuthorNotification.inc.php
+++ b/pprOjsPlugin/tasks/PPRSubmissionClosedAuthorNotification.inc.php
@@ -1,0 +1,135 @@
+<?php
+
+use function PHP81_BC\strftime;
+
+require_once(dirname(__FILE__) . '/PPRScheduledTask.inc.php');
+
+/**
+ * Notification, in the form of an email, to authors. The email will be sent a period of time after
+ * a submission is closed. This is used to send a survey to the author.
+ * The initial requirement was to send an email after a year of the closed submission,
+ * but the time in days is configurable in the plugin settings.
+ */
+class PPRSubmissionClosedAuthorNotification extends PPRScheduledTask {
+
+    const EMAIL_TEMPLATE = 'PPR_SUBMISSION_CLOSED_AUTHOR';
+
+    function __construct($args, $pprObjectFactory = null) {
+        parent::__construct($args, $pprObjectFactory);
+    }
+
+    function getName() {
+        return 'PPRSubmissionClosedAuthorNotification';
+    }
+
+    function sendNotification ($submission, $context) {
+        $author = $this->getSubmissionAuthor($submission->getId());
+
+        if (!$author) {
+            $this->log($context, sprintf("Send Notification - No author assigned submissionId=%s", $submission->getId()));
+            return;
+        }
+
+        import('lib.pkp.classes.mail.SubmissionMailTemplate');
+        $email = new SubmissionMailTemplate($submission, self::EMAIL_TEMPLATE, $context->getPrimaryLocale(), $context, false);
+        $email->setContext($context);
+        $email->setReplyTo(null);
+        $email->addRecipient($author->getEmail(), $author->getFullName());
+        $email->setSubject($email->getSubject());
+        $email->setBody($email->getBody());
+        $email->setFrom($context->getData('contactEmail'), $context->getData('contactName'));
+
+        $application = Application::get();
+        $request = $application->getRequest();
+        $dispatcher = $application->getDispatcher();
+        $submissionUrl = $dispatcher->url($request, ROUTE_PAGE, $context->getPath(), 'workflow', 'access', [$submission->getId()]);
+
+        AppLocale::requireComponents(LOCALE_COMPONENT_PKP_REVIEWER);
+        AppLocale::requireComponents(LOCALE_COMPONENT_PKP_COMMON);
+
+        // EDITOR NAMES WILL BE ADDED BY services/email/PPRFirstNameEmailService
+        $email->assignParams([
+            'authorFirstName' => htmlspecialchars($author->getLocalizedGivenName()),
+            'authorName' => htmlspecialchars($author->getFullName()),
+            'editorialContactSignature' => htmlspecialchars($context->getData('contactName') . "\n" . $context->getLocalizedName()),
+            'submissionUrl' => $submissionUrl,
+        ]);
+
+        $email->send();
+    }
+
+    function executeForContext($context, $pprPluginSettings) {
+        if (!$pprPluginSettings->submissionClosedAuthorTaskEnabled()) {
+            // THIS IS REQUIRED HERE AS THE CONFIGURED SCHEDULED TASKS ARE LOADED BY THE acron PLUGIN WHEN IT IS RELOADED
+            $this->log($context, 'submissionClosedAuthorTaskEnabled=false');
+            return;
+        }
+
+        $this->log($context, "Start");
+
+        $metrics = [
+            'submissions' => 0,
+            'closedSubmissions' => 0,
+            'closedSubmissionsAfterPeriod' => 0,
+            'closedSubmissionsWithNotifications' => 0,
+            'sendToAuthorMissing' => 0,
+            'sentNotifications' => 0,
+        ];
+
+        $submissionClosedWaitingDays = $pprPluginSettings->submissionClosedAuthorWaitingDays();
+        $pprNotificationRegistry = new PPRTaskNotificationRegistry($context->getId());
+        $submissionDao = DAORegistry::getDAO('SubmissionDAO');
+        $allSubmissions = $submissionDao->getByContextId($context->getId());
+
+        $closedSubmissions = [];
+        while ($submission = $allSubmissions->next()) {
+            $metrics['submissions']++;
+            $closedDate = $submission->getData('closedDate');
+            if ($closedDate) {
+                $metrics['closedSubmissions']++;
+                $closedSubmissions[] = $submission;
+            }
+        }
+
+        $this->log($context, sprintf("Submissions to process - allSubmissions=%s closedSubmissions=%s", $metrics['submissions'], $metrics['closedSubmissions']));
+
+        // METRICS
+        foreach ($closedSubmissions as $closedSubmission) {
+            $closedDate = strtotime($closedSubmission->getData('closedDate'));
+            if (time() - $closedDate > 60 * 60 * 24 * $submissionClosedWaitingDays) {
+                $metrics['closedSubmissionsAfterPeriod']++;
+
+                if (!$this->requestedRevisionsForSubmission($closedSubmission)) {
+                    $this->log($context, sprintf("sendToAuthor not found - closedSubmission=%s", $closedSubmission->getId()));
+                    $metrics['sendToAuthorMissing']++;
+                    continue;
+                }
+
+                $authorNotifications = $pprNotificationRegistry->getSubmissionClosedAuthorNotification($closedSubmission->getId());
+                if (empty($authorNotifications)) {
+                    $this->sendNotification($closedSubmission, $context);
+                    $pprNotificationRegistry->registerSubmissionClosedAuthorNotification($closedSubmission->getId());
+                    $metrics['sentNotifications']++;
+                } else {
+                    $metrics['closedSubmissionsWithNotifications']++;
+                }
+            }
+        }
+
+        $this->log($context, sprintf("Completed - closedSubmissions=%s closedSubmissionsAfterPeriod=%s sendToAuthorMissing=%s closedSubmissionsWithNotifications=%s sentNotifications=%s", $metrics['closedSubmissions'], $metrics['closedSubmissionsAfterPeriod'], $metrics['sendToAuthorMissing'], $metrics['closedSubmissionsWithNotifications'], $metrics['sentNotifications']));
+    }
+
+    private function requestedRevisionsForSubmission($submission) {
+        $editDecisionDao = DAORegistry::getDAO('EditDecisionDAO');
+        $editorDecisions = $editDecisionDao->getEditorDecisions($submission->getId());
+        foreach ($editorDecisions as $decision) {
+            if ($decision['decision'] === SUBMISSION_EDITOR_DECISION_PENDING_REVISIONS) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}
+
+

--- a/pprOjsPlugin/tasks/PPRTaskNotificationRegistry.inc.php
+++ b/pprOjsPlugin/tasks/PPRTaskNotificationRegistry.inc.php
@@ -10,6 +10,7 @@ class PPRTaskNotificationRegistry {
     public const REVIEW_PENDING_WITH_FILES_REVIEWER_NOTIFICATION = 80880600;
     public const REVIEW_SENT_AUTHOR_NOTIFICATION = 80880700;
     public const SUBMISSION_AUTHOR_SURVEY = 80880800;
+    public const SUBMISSION_CLOSED_AUTHOR_NOTIFICATION = 80880900;
 
     private $notificationDao;
     private $contextId;
@@ -70,6 +71,15 @@ class PPRTaskNotificationRegistry {
 
     public function getSubmissionSurveyForAuthor($userId) {
         $items = $this->getNotifications(self::SUBMISSION_AUTHOR_SURVEY, $userId, $userId);
+        return $items->toArray();
+    }
+
+    public function registerSubmissionClosedAuthorNotification($submissionId) {
+        return $this->saveNotification(self::SUBMISSION_CLOSED_AUTHOR_NOTIFICATION, $submissionId, $submissionId);
+    }
+
+    public function getSubmissionClosedAuthorNotification($submissionId) {
+        $items = $this->getNotifications(self::SUBMISSION_CLOSED_AUTHOR_NOTIFICATION, $submissionId, $submissionId);
         return $items->toArray();
     }
 

--- a/pprOjsPlugin/templates/ppr/pluginSettingsForm.tpl
+++ b/pprOjsPlugin/templates/ppr/pluginSettingsForm.tpl
@@ -113,6 +113,11 @@
 		    </div>
 
 			<div class="subsection">
+				{fbvElement type="checkbox" name="submissionClosedAuthorTaskEnabled" label="plugins.generic.pprPlugin.settings.submissionClosedAuthorTaskEnabled.label" id="submissionClosedAuthorTaskEnabled" checked=$submissionClosedAuthorTaskEnabled}
+				{fbvElement type="text" name="submissionClosedAuthorWaitingDays" label="plugins.generic.pprPlugin.settings.submissionClosedAuthorWaitingDays.label" id="submissionClosedAuthorWaitingDays" value=$submissionClosedAuthorWaitingDays}
+			</div>
+
+			<div class="subsection">
 				{fbvElement type="checkbox" name="scheduledTasksReset" label="plugins.generic.pprPlugin.settings.scheduledTasksReset.label" id="scheduledTasksReset"}
 			</div>
 		{/fbvFormSection}

--- a/pprOjsPlugin/tests/src/settings/PPRPluginSettingsTest.php
+++ b/pprOjsPlugin/tests/src/settings/PPRPluginSettingsTest.php
@@ -50,6 +50,8 @@ class PPRPluginSettingsTest extends PPRTestCase {
             'reviewAddEditorToBccEnabled' => [null, null],
             'reviewUploadFileValidationEnabled' => [null, null],
             'reviewAttachmentsOverrideEnabled' => [null, null],
+            'submissionClosedAuthorTaskEnabled' => [null, null],
+            'submissionClosedAuthorWaitingDays' => [null, 365],
             'firstNameEmailEnabled' => [null, true],
             'reviewerRegistrationEmailDisabled' => [null, null],
             'reviewAcceptedEmailEnabled' => [null, null],

--- a/pprOjsPlugin/tests/src/tasks/PPRTaskNotificationRegistryTest.php
+++ b/pprOjsPlugin/tests/src/tasks/PPRTaskNotificationRegistryTest.php
@@ -215,6 +215,27 @@ class PPRTaskNotificationRegistryTest extends PPRTestCase {
         $this->assertEquals($this->EXPECTED_NOTIFICATION_ARRAY, $result);
     }
 
+    public function test_registerSubmissionClosedAuthorNotification_inserts_the_expected_notification() {
+        $reviewDueDateNotificationType = PPRTaskNotificationRegistry::SUBMISSION_CLOSED_AUTHOR_NOTIFICATION;
+        $userId = $this->getRandomId();
+        $this->addCreateNotificationMock($reviewDueDateNotificationType, $userId, $userId);
+
+        $target = new PPRTaskNotificationRegistry(self::CONTEXT_ID);
+
+        $target->registerSubmissionClosedAuthorNotification($userId);
+    }
+
+    public function test_getSubmissionClosedAuthorNotification_calls_NotificationDAO() {
+        $reviewDueDateNotificationType = PPRTaskNotificationRegistry::SUBMISSION_CLOSED_AUTHOR_NOTIFICATION;
+        $userId = $this->getRandomId();
+        $this->addGetNotificationMock($reviewDueDateNotificationType, $userId, $userId);
+
+        $target = new PPRTaskNotificationRegistry(self::CONTEXT_ID);
+
+        $result = $target->getSubmissionClosedAuthorNotification($userId);
+        $this->assertEquals($this->EXPECTED_NOTIFICATION_ARRAY, $result);
+    }
+
     public function test_updateDateRead_calls_NotificationDAO() {
         $notificationId = $this->getRandomId();
         $notificationDao = $this->createMock(NotificationDAO::class);

--- a/pprOjsPlugin/tests/src/tasks/PPRTaskNotificationRegistryTest.php
+++ b/pprOjsPlugin/tests/src/tasks/PPRTaskNotificationRegistryTest.php
@@ -217,22 +217,22 @@ class PPRTaskNotificationRegistryTest extends PPRTestCase {
 
     public function test_registerSubmissionClosedAuthorNotification_inserts_the_expected_notification() {
         $reviewDueDateNotificationType = PPRTaskNotificationRegistry::SUBMISSION_CLOSED_AUTHOR_NOTIFICATION;
-        $userId = $this->getRandomId();
-        $this->addCreateNotificationMock($reviewDueDateNotificationType, $userId, $userId);
+        $submissionId = $this->getRandomId();
+        $this->addCreateNotificationMock($reviewDueDateNotificationType, $submissionId, $submissionId);
 
         $target = new PPRTaskNotificationRegistry(self::CONTEXT_ID);
 
-        $target->registerSubmissionClosedAuthorNotification($userId);
+        $target->registerSubmissionClosedAuthorNotification($submissionId);
     }
 
     public function test_getSubmissionClosedAuthorNotification_calls_NotificationDAO() {
         $reviewDueDateNotificationType = PPRTaskNotificationRegistry::SUBMISSION_CLOSED_AUTHOR_NOTIFICATION;
-        $userId = $this->getRandomId();
-        $this->addGetNotificationMock($reviewDueDateNotificationType, $userId, $userId);
+        $submissionId = $this->getRandomId();
+        $this->addGetNotificationMock($reviewDueDateNotificationType, $submissionId, $submissionId);
 
         $target = new PPRTaskNotificationRegistry(self::CONTEXT_ID);
 
-        $result = $target->getSubmissionClosedAuthorNotification($userId);
+        $result = $target->getSubmissionClosedAuthorNotification($submissionId);
         $this->assertEquals($this->EXPECTED_NOTIFICATION_ARRAY, $result);
     }
 


### PR DESCRIPTION
Scheduled task to send a notification to an author a year after a submission is closed.

The period of time is configurable through the plugin settings.

The notification is an email and it will be used to send a survey